### PR TITLE
ci: ignore jupyter-book in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "jupyter-book"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Skip jupyter-book version updates from dependabot.

## Summary by Sourcery

Build:
- Configure Dependabot to ignore version updates for the jupyter-book Python dependency.